### PR TITLE
Update __init__.py

### DIFF
--- a/src/AutoItLibrary/__init__.py
+++ b/src/AutoItLibrary/__init__.py
@@ -240,8 +240,11 @@ class AutoItLibrary(Logger.Logger, Counter.Counter) :
         #
         # Embed the screenshot in the Robot Framework log file
         #
+        # Browsers are double encoding path if there is not 'file://'
+        fullFilePath = 'file://' + fullFilePath
+        # Embeded screenshot need to have a full path if there is not default Output directory
         self._html('<td></td></tr><tr><td colspan="3"><a href="%s">'
-                   '<img src="%s" width="700px"></a></td></tr>' % (FilePath, FilePath))
+                   '<img src="%s" width="700px"></a></td></tr>' % (fullFilePath, fullFilePath))
     #
     #-------------------------------------------------------------------------------
     #


### PR DESCRIPTION
- Browsers were double encoding path to embedded screenshot if there were special characters
  path = C:\This is a test
  double encoded path = C:\This%2520is%2520a%2520test
- using full path to screenshots, because output directory can be different
